### PR TITLE
Update announcement message for 9.2.0

### DIFF
--- a/_posts/2024-06-07-octave-9.2.0-released.markdown
+++ b/_posts/2024-06-07-octave-9.2.0-released.markdown
@@ -9,10 +9,17 @@ GNU Octave version 9.2.0 has been released and is now available for
 [download][1].  An official [Windows binary installer][2] is available.
 For [macOS][3] see the installation instructions in the wiki.
 
-This major release improves the graphics backend, compatibility with
-Matlab and contains many new and improved functions.  A list of important
-user-visible changes is available by selecting the [Release Notes][4] item
-in the News menu of the GUI or by typing `news` at the Octave command prompt.
+* Fix for an overlinking issue for built `.oct` files. If you are
+  concerned by overlinking, re-built binaries that you built with
+  `mkoctfile` in version 9.1.0 with the new version.
+* Better support for HiDPI scaling.
+* Fixes for newer versions of Qt6.
+
+Additionally, the Windows binaries are now built with Qt6.
+
+A list of important user-visible changes is available by selecting the
+[Release Notes][4] item in the News menu of the GUI or by typing `news`
+at the Octave command prompt.
 
 Thanks to the many people who contributed to this release!
 
@@ -20,4 +27,3 @@ Thanks to the many people who contributed to this release!
 [2]: https://ftpmirror.gnu.org/octave/windows/
 [3]: {{ site.wiki_url }}/Octave_for_macOS
 [4]: {{ "NEWS-9.html" | absolute_url }}
-


### PR DESCRIPTION
I copied the announcement for the version 9.2.0 from the announcement for version 9.1.0. But I forgot to actually update it (apart from a quick replacement of the version numbers) for #13. I only noticed that when I was about to copy parts of the announcement to Discourse.

I'm very sorry for that.

@siko1056: Would it be possible to change the announcement after it has already been published? Or would it be better to add a new announcement?
