### PR TITLE
GNU Octave 10.2.0 release (2025-05-29)

### DIFF
--- a/_posts/2025-06-03-octave-10.2.0-released.markdown
+++ b/_posts/2025-06-03-octave-10.2.0-released.markdown
@@ -1,0 +1,26 @@
+---
+layout: post
+title:  "GNU Octave 10.2.0 Released"
+date:   2025-06-03
+categories: news release
+---
+
+GNU Octave version 10.2.0 has been released and is now available for
+[download][1].  An official [Windows binary installer][2] is available.
+For [macOS][3] see the installation instructions in the wiki.
+
+* Fix missing symbol errors when installing some Octave packages.
+* Many other fixes and improvements that have been found since the release
+  of Octave 10.1.0.
+
+A list of important user-visible changes is available by selecting the
+[Release Notes][4] item in the News menu of the GUI or by typing `news` at
+the Octave command prompt.
+
+Thanks to the many people who contributed to this release!
+
+[1]: {{ "download.html" | absolute_url }}
+[2]: https://ftpmirror.gnu.org/gnu/octave/windows/
+[3]: {{ site.wiki_url }}/Octave_for_macOS
+[4]: {{ "NEWS-10.html" | absolute_url }}
+

--- a/pages/NEWS.10.md
+++ b/pages/NEWS.10.md
@@ -193,6 +193,11 @@ major release after 10):
         __lo_ieee_isfinite, __lo_ieee_float_isfinite | std::isfinite  or  isfinite
         __lo_ieee_isinf,    __lo_ieee_float_isinf    | std::isinf     or  isinf
         __lo_ieee_signbit,  __lo_ieee_float_signbit  | std::signbit   or  signbit
+        octave_value (const Array<octave_value>& a)  | octave_value (const Cell&)
+
+  - The `octave_value (const Array<octave_value>& a)` constructor will already
+    be removed in Octave 11 (or whatever version is the next major release
+    after Octave 10).
 
   - A new method `rwdata ()` provides direct read/write access (a pointer) to
     the data in a liboctave `Array` object (or its derived classes such as
@@ -341,3 +346,88 @@ Summary of bugs fixed for version 10.1.0 (2025-03-28):
 - [bug #41028](https://savannah.gnu.org/bugs/?41028): `lastwarn`: Save warning info for disabled warnings.
 - [bug #41028](https://savannah.gnu.org/bugs/?41028): Modify built-in self-tests to pass with Matlab-compatible
   `lastwarn()` behavior.
+
+
+## Summary of bugs fixed for version 10.2.0 (2025-05-29):
+
+### Improvements and fixes
+
+- `tensorprod`: Fix error for certain tensor/vector combinations ([bug #66950](https://savannah.gnu.org/bugs/?66950)).
+- `mkoctfile`: Skip compiling object file with soversion for `--mex -c -o`
+  ([bug #66972](https://savannah.gnu.org/bugs/?66972)).
+- Fix segmentation fault in `octave-svgconvert` when called with no inputs.
+- `mkoctfile`: Remove temporary C source files after compilation.
+- `unicode2native`: Fix conversion of short strings to UTF-16 or UTF-32.
+- Detect leading and trailing comments for all parse tree elements
+  ([bug #67004](https://savannah.gnu.org/bugs/?67004)).
+- `bar`: Avoid listener error when replacing an existing bar plot ([bug #67006](https://savannah.gnu.org/bugs/?67006)).
+- Fix sparse matrix assignment with reverse range indexing ([bug #66516](https://savannah.gnu.org/bugs/?66516)).
+- `ezplot`: Enable polar and 2-D plots of constant functions ([bug #66563](https://savannah.gnu.org/bugs/?66563)).
+- Check for any kind of file not just regular files ([bug #67018](https://savannah.gnu.org/bugs/?67018)).
+- `var`/`std`: Issue an error for non-floating point inputs. Previous versions
+  accepted integer type inputs but could produce erroneous outputs due to
+  integer arithmetic and under/overflow errors ([bug #67016](https://savannah.gnu.org/bugs/?67016)).
+- `annotation`: Change `"verticalalignment"` default value ([bug #67033](https://savannah.gnu.org/bugs/?67033)).
+- Previously, symbols that are not actually callable by a user might have been
+  added to the list of callable functions when loading .mex files.  Remove
+  these symbols from that list.  This fixes unloading .mex files with `clear`.
+- Remove break points only from user functions (defined in .m file).  This
+  fixes an infinite recursion issue when re-loading updated .oct or .mex files.
+- For improved Matlab compatibility the `strncmp` and `strncmpi` functions now
+  return `true` if the number of characters specified by `N` is equal to 0
+  ([bug #57879](https://savannah.gnu.org/bugs/?57879)).
+- Fix `nargout` in multi-output indexing expressions beginning with function
+  call ([bug #67096](https://savannah.gnu.org/bugs/?67096)).
+- `findobj`: Do not match empty tags with `[]` ([bug #67048](https://savannah.gnu.org/bugs/?67048)).
+- Check for undefined output when indexing function output ([bug #67111](https://savannah.gnu.org/bugs/?67111)).
+- `perms`: Fix buffer overflow and crash; minor code cleanup ([bug #67115](https://savannah.gnu.org/bugs/?67115)).
+- `mkoctfile`: Support spaces in output path of linker step.
+- `mkoctfile`: Support spaces in path to binary when stripping debug info.
+- `octave-svgconvert`: Speed up printing to PDF ([bug #66959](https://savannah.gnu.org/bugs/?66959)).
+- `error`: Fix segmentation fault on missing fields in `err.stack` structure
+  ([bug #67143](https://savannah.gnu.org/bugs/?67143)).
+- Avoid parse error for empty lines in debug mode ([bug #67108](https://savannah.gnu.org/bugs/?67108)).
+- Check if effective SOVERSION is exported from .mex file libraries
+  ([bug #67163](https://savannah.gnu.org/bugs/?67163)).
+
+### GUI
+
+- Fix build error without QScintilla installed ([bug #66962](https://savannah.gnu.org/bugs/?66962)).
+- Avoid potential integer overflow on Windows.
+- Make dialogs shown by `inputdlg`, `listdlg`, `questdlg`, `uigetdir`, or
+  `uigetfile` modal.
+
+### Build system / Tests
+
+- Add visibility attributes for the `octave::base_fcn_handle` class.
+- Add visibility attributes to parse tree symbols ([bug #67056](https://savannah.gnu.org/bugs/?67056)).
+- Add visibility attributes to `Array<T>` template class member functions.
+- Use correct preprocessor macro when instantiating `MArray` template class.
+- Disable visibility flags by default.
+- Support passing additional flags when linking `octave*` executables.
+- Single-quote path that might contain unescaped backslashes in the generation
+  of the doc cache.
+- Ignore deprecation warning for `std::wbuffer_convert` in header.
+- `error`: Add more built-in self-tests.
+
+### Documentation
+
+- Recommend use of string function name as first argument to `cellfun()`.
+- `cellfun`: Call out special accelerated functions.
+- Update documentation for `feval`, `eval`, `evalin`, `evalc`.
+- `axis`: Remove incorrect statement from documentation.
+- Do not put graphics object categories into Graphic Properties Index.
+- Adjust Perl regexp used to remove leading ':' in HTML.
+- `char`: Document calling form with no inputs.
+- Fix missing hyperlinks in Table of Contents of Octave manual.
+- Fix overfull hbox warnings in Texinfo log files.
+- Replace Texinfo `@dots` macro with `@enddots` macro where appropriate.
+- Do not print ugly black boxes for overfull hboxes in PDF output.
+- Fix accidental doc text inclusions after `@deftypefn`.
+- Remove reference to Octave Forge in `stats.txi`.
+- Document use of `:` keyword as a range operator.
+- Correct and expand documentation on ranges.
+- Remove outdated text on range arithmetic from manual.
+- Examples: Add missing namespace `octave` when calling built-in function in
+  `standalonebuiltin.cc`.
+- Document calling `error()` with structure input ([bug #67143](https://savannah.gnu.org/bugs/?67143)).

--- a/pages/community-news.html
+++ b/pages/community-news.html
@@ -14,7 +14,7 @@ the `community-news-page-serial` number by one in order to show new
 entries in the GUI:
 
   this-is-the-gnu-octave-community-news-page
-  community-news-page-serial=29
+  community-news-page-serial=30
 
 -->
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -8,7 +8,7 @@ permalink: download
 
 <div class="primary callout">
   <i class="fas fa-info-circle" style="color:#1779ba;"></i>
-  <strong>GNU Octave 10.1.0</strong> is the latest stable release.
+  <strong>GNU Octave 10.2.0</strong> is the latest stable release.
   (<a href="{{ "/NEWS-10.html" | relative_url }}">Release Notes</a>)
 </div>
 
@@ -90,15 +90,15 @@ After installation type <code>pkg list</code> to list them.<br>
 </div>
 
 - Windows-64 (recommended)
-  - [octave-10.1.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-installer.exe)
+  - [octave-10.2.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-installer.exe)
     (~ 510 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-installer.exe.sig)
-  - [octave-10.1.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-installer.exe.sig)
+  - [octave-10.2.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.7z)
     (~ 425 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64.7z.sig)
-  - [octave-10.1.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.7z.sig)
+  - [octave-10.2.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.zip)
     (~ 760 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.zip.sig)
 
 <p></p>
 
@@ -111,15 +111,15 @@ After installation type <code>pkg list</code> to list them.<br>
   version above.
   </small>
 
-  - [octave-10.1.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64-installer.exe)
+  - [octave-10.2.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64-installer.exe)
     (~ 510 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64-installer.exe.sig)
-  - [octave-10.1.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64-installer.exe.sig)
+  - [octave-10.2.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.7z)
     (~ 425 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64.7z.sig)
-  - [octave-10.1.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.7z.sig)
+  - [octave-10.2.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.zip)
     (~ 760 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.1.0-w64-64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.zip.sig)
 
 <p></p>
 


### PR DESCRIPTION
@jwe uploaded the artifacts for this version a couple of hours ago.
Maybe, we should wait a day or so for the mirrors to catch up before deploying these changes (if they are ok).
