### PR TITLE
GNU Octave 10.3.0 release (2025-09-23)

### DIFF
--- a/_posts/2025-10-01-octave-10.3.0-released.markdown
+++ b/_posts/2025-10-01-octave-10.3.0-released.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "GNU Octave 10.3.0 Released"
+date:   2025-10-01
+categories: news release
+---
+
+GNU Octave version 10.3.0 has been released and is now available for
+[download][1].  An official [Windows binary installer][2] is available.
+For [macOS][3] see the installation instructions in the wiki.
+
+* Many fixes and improvements that have been found since the release of
+  Octave 10.2.0.
+
+A list of important user-visible changes is available by selecting the
+[Release Notes][4] item in the News menu of the GUI or by typing `news` at
+the Octave command prompt.
+
+Thanks to the many people who contributed to this release!
+
+[1]: {{ "download.html" | absolute_url }}
+[2]: https://ftpmirror.gnu.org/gnu/octave/windows/
+[3]: {{ site.wiki_url }}/Octave_for_macOS
+[4]: {{ "NEWS-10.html" | absolute_url }}
+

--- a/pages/NEWS.10.md
+++ b/pages/NEWS.10.md
@@ -431,3 +431,64 @@ Summary of bugs fixed for version 10.1.0 (2025-03-28):
 - Examples: Add missing namespace `octave` when calling built-in function in
   `standalonebuiltin.cc`.
 - Document calling `error()` with structure input ([bug #67143](https://savannah.gnu.org/bugs/?67143)).
+
+## Summary of bugs fixed for version 10.3.0 (2025-09-23):
+
+### Improvements and fixes
+
+- Correctly interpret command line option `--no-init-user` ([bug #67187](https://savannah.gnu.org/bugs/?67187)).
+- `image`: Avoid error if image data is empty ([bug #65866](https://savannah.gnu.org/bugs/?65866)).
+- Respect logarithmic scaling of axis when plotting scatter objects
+  ([bug #67239](https://savannah.gnu.org/bugs/?67239)).
+- Avoid segmentation fault with display with too low color depth ([bug #65866](https://savannah.gnu.org/bugs/?65866)).
+- Store save type in `binary-float` format also for empty matrices
+  ([bug #67271](https://savannah.gnu.org/bugs/?67271)).
+- Fix ASAN bug in liboctave `svd` code caused by use of
+  `std::vector::reserve ()` ([bug #67248](https://savannah.gnu.org/bugs/?67248)).
+- `mldivide`: Correctly apply permutation for sparse matrix with permuted lower
+  form.
+- Allow empty field names in `struct` and `cell2struct` functions ([bug #67255](https://savannah.gnu.org/bugs/?67255)).
+- `containers.Map`: Allow empty `char` arrays as keys ([bug #67255](https://savannah.gnu.org/bugs/?67255)).
+- Fix ASAN warnings in `__ilu__.cc` ([bug #67249](https://savannah.gnu.org/bugs/?67249)).
+- `rose.m`: Fix regression where output variables always returned ([bug #48889](https://savannah.gnu.org/bugs/?48889)).
+- `rose.m`: Overhaul function to resolve incorrect custom bin placement
+  ([bug #67280](https://savannah.gnu.org/bugs/?67280)).
+- Clarify the `"Octave:language-extension"` warning message for comparing
+  complex numbers that the compatibility difference is that Octave considers
+  the complex part of the number ([bug #67257](https://savannah.gnu.org/bugs/?67257)).
+- `delaunayn.m`: Check inputs for non-finite values to avoid segfault in QHull
+  ([bug #67315](https://savannah.gnu.org/bugs/?67315)).
+- Fix calculation of "nearest integer" function ([bug #67339](https://savannah.gnu.org/bugs/?67339)).
+- `struct2hdl.m`: Use a consistent output type for `valcomp` ([bug #67217](https://savannah.gnu.org/bugs/?67217)).
+- Avoid crash when Octave invoked with `-d` argument.
+- Skip saving too large arrays in `-binary` format ([bug #67382](https://savannah.gnu.org/bugs/?67382)).
+- Write and read large array in chunks for `-binary` file format ([bug #67382](https://savannah.gnu.org/bugs/?67382)).
+- Correctly parse `clear ?` ([bug #67459](https://savannah.gnu.org/bugs/?67459)).
+- `colorbar.m`: Don't emit error if "position" property given ([bug #67537](https://savannah.gnu.org/bugs/?67537)).
+
+### GUI
+
+- Fix `SIGABRT` on exit of GUI ([bug #67230](https://savannah.gnu.org/bugs/?67230)).
+- Fix focus when reopening editor file from MRU list ([bug #67384](https://savannah.gnu.org/bugs/?67384)).
+
+### Build system / Tests
+
+- Add tests for shadowed functions in core Octave ([bug #46849](https://savannah.gnu.org/bugs/?46849)).
+- Fix building Java on solaris2 platforms ([bug #67442](https://savannah.gnu.org/bugs/?67442)).
+- Include `ida.h` in configure tests from the locations at which it is looked
+  for.
+- Do not check for `nvector_serial.h` without folder in configure test.
+
+### Documentation
+
+- Expand on orthogonality properties of the cross product ([bug #67186](https://savannah.gnu.org/bugs/?67186)).
+- Remove newline before `@tex` invocation for better alignment.
+- Remove notes in documentation scheduled for deletion in version 9.1.
+- Clarify use of "interpreter" property when printing.
+- Improve TeX output for vector calculus functions.
+- Explain more clearly uses and pitfalls of `NA`.
+- Add documentation for hexadecimal and binary integer constants ([bug #67645](https://savannah.gnu.org/bugs/?67645)).
+- Use `IEEE@tie{}754` when referring to floating point standard.
+- `diary`: Clarify documentation.
+- `echo`: Clarify documentation.
+- Update manual for `--traditional` option to note that `PS4` is set.

--- a/pages/community-news.html
+++ b/pages/community-news.html
@@ -14,7 +14,7 @@ the `community-news-page-serial` number by one in order to show new
 entries in the GUI:
 
   this-is-the-gnu-octave-community-news-page
-  community-news-page-serial=30
+  community-news-page-serial=31
 
 -->
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -8,7 +8,7 @@ permalink: download
 
 <div class="primary callout">
   <i class="fas fa-info-circle" style="color:#1779ba;"></i>
-  <strong>GNU Octave 10.2.0</strong> is the latest stable release.
+  <strong>GNU Octave 10.3.0</strong> is the latest stable release.
   (<a href="{{ "/NEWS-10.html" | relative_url }}">Release Notes</a>)
 </div>
 
@@ -90,15 +90,15 @@ After installation type <code>pkg list</code> to list them.<br>
 </div>
 
 - Windows-64 (recommended)
-  - [octave-10.2.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-installer.exe)
+  - [octave-10.3.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-installer.exe)
     (~ 510 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-installer.exe.sig)
-  - [octave-10.2.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-installer.exe.sig)
+  - [octave-10.3.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.7z)
     (~ 425 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.7z.sig)
-  - [octave-10.2.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.7z.sig)
+  - [octave-10.3.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.zip)
     (~ 760 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.zip.sig)
 
 <p></p>
 
@@ -111,15 +111,15 @@ After installation type <code>pkg list</code> to list them.<br>
   version above.
   </small>
 
-  - [octave-10.2.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64-installer.exe)
+  - [octave-10.3.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64-installer.exe)
     (~ 510 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64-installer.exe.sig)
-  - [octave-10.2.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64-installer.exe.sig)
+  - [octave-10.3.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64.7z)
     (~ 425 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.7z.sig)
-  - [octave-10.2.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64.7z.sig)
+  - [octave-10.3.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64.zip)
     (~ 760 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.2.0-w64-64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64-64.zip.sig)
 
 <p></p>
 


### PR DESCRIPTION
@jwe tagged and uploaded a new release a few hours ago.

Maybe, we should wait a day or two before announcing the release on the website so that the mirrors have a chance to catch up.
I'll leave the PR open for now.
