### PR TITLE
Recommend secure protocol to download public key.

### DIFF
--- a/pages/download.md
+++ b/pages/download.md
@@ -34,7 +34,7 @@ Please download from
 [https://ftpmirror.gnu.org/octave](https://ftpmirror.gnu.org/octave),
 which will redirect automatically to a nearby
 [mirror site](https://www.gnu.org/order/ftp.html).
- 
+
 Users are encouraged to verify the Octave installation file they download
 (such as `octave-10.3.0.tar.xz`) as follows:
 * First, ensure that you are downloading from the official Octave website, or

--- a/pages/download.md
+++ b/pages/download.md
@@ -42,10 +42,10 @@ from a GNU mirror linked from the official Octave website.
 * Next, download the corresponding signature file for the installation file
 you downloaded, for example if you intend to install `octave-10.3.0.tar.xz` then
 download the signature `octave-10.3.0.tar.xz.sig`.
-* Next, run the following command to import a public key (this needs to be done
-  only once).
+* Next, run the following command to import John W. Eaton's public key (this
+  needs to be done only once).
   ```
-  gpg --keyserver hkp://keys.gnupg.net --recv-keys 5D36644B
+  gpg --keyserver hkps://keys.gnupg.net --recv-keys B05F05B75D36644B
   ```
 * Finally, verify the integrity of the file you downloaded with a command like
   ```
@@ -57,7 +57,7 @@ download the signature `octave-10.3.0.tar.xz.sig`.
   ```
   in which case you can install Octave from that file.
 * If the file you downloaded was corrupted or changed by anyone else, then
-the output will say
+  the output will say
   ```
   gpg: BAD signature from "John W. Eaton <jwe@gnu.org>".
   ```


### PR DESCRIPTION
@pr0m1th3as: Noticed that after you pointed to that page during the online office hour yesterday.

Also, I don't recall reading anywhere else that a (compressed) source tarball is called an "installation file". Should the wording regarding that be changed, too?

In the sentence "If the file you downloaded was corrupted or changed...", I'd expect to read "is corrupt or was changed" instead of "corrupted". Maybe, even something more generic would be better. Like "If the signature does not match the file that you downloaded...".
But I'm not a native speaker.

