### PR TITLE
GNU Octave 11.3.0 release (2026-06-01)

### DIFF
--- a/_posts/2026-05-28-octave-11.2.0-released.markdown
+++ b/_posts/2026-05-28-octave-11.2.0-released.markdown
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  "GNU Octave 11.2.0 Released"
+date:   2026-05-28
+categories: news release
+---
+
+GNU Octave version 11.2.0 has been released and is now available for
+[download][1].  An official [Windows binary installer][2] is available.
+For [macOS][3] see the installation instructions in the wiki.
+
+> **_Note:_** The SOVERSION of the `liboctinterp` library is incorrect in this
+> version.  Update to Octave 11.3.0 instead.
+
+* Many fixes and improvements that have been found since the release of
+  Octave 11.1.0.
+
+A list of important user-visible changes is available by selecting the
+[Release Notes][4] item in the News menu of the GUI or by typing `news` at
+the Octave command prompt.
+
+Thanks to the many people who contributed to this release!
+
+[1]: {{ "download.html" | absolute_url }}
+[2]: https://ftpmirror.gnu.org/gnu/octave/windows/
+[3]: {{ site.wiki_url }}/Octave_for_macOS
+[4]: {{ "NEWS-11.html" | absolute_url }}
+

--- a/_posts/2026-06-01-octave-11.3.0-released.markdown
+++ b/_posts/2026-06-01-octave-11.3.0-released.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "GNU Octave 11.3.0 Released"
+date:   2026-06-01
+categories: news release
+---
+
+GNU Octave version 11.3.0 has been released and is now available for
+[download][1].  An official [Windows binary installer][2] is available.
+For [macOS][3] see the installation instructions in the wiki.
+
+* This version brings only minor changes compared to Octave 11.2.0.  Most
+  importantly, it fixes the SOVERSION of the `liboctinterp` library.
+
+A list of important user-visible changes is available by selecting the
+[Release Notes][4] item in the News menu of the GUI or by typing `news` at
+the Octave command prompt.
+
+Thanks to the many people who contributed to this release!
+
+[1]: {{ "download.html" | absolute_url }}
+[2]: https://ftpmirror.gnu.org/gnu/octave/windows/
+[3]: {{ site.wiki_url }}/Octave_for_macOS
+[4]: {{ "NEWS-11.html" | absolute_url }}
+

--- a/pages/NEWS.11.md
+++ b/pages/NEWS.11.md
@@ -375,3 +375,14 @@ from Octave 11.
 - Set Texinfo `@exampleindent` for better visual appearance.
 - `linsolve.m`: Update documentation ([bug #68283](https://savannah.gnu.org/bugs/?68283)).
 - Update all man pages with new information and modern `groff` syntax.
+
+
+## Summary of bugs fixed for version 11.3.0 (2025-06-01):
+
+This version brings only minor changes compared to Octave 11.2.0.  Most
+importantly, it fixes the SOVERSION of the `liboctinterp` library.
+
+### Improvements and fixes
+
+- Fix returning reciprocal condition number as second output from `det` for
+  triangular dense matrices.

--- a/pages/NEWS.11.md
+++ b/pages/NEWS.11.md
@@ -21,9 +21,7 @@ February 18, 2026
 ### General improvements
 
 - The internal interface to Java has been updated to be more memory-efficient
-  (faster culling of unused objects).  Building Octave from source code with
-  Java support now requires JDK 1.9 or newer.  Distributed, precompiled
-  versions of Octave will run with any JVM.
+  (faster culling of unused objects).  Octave now requires JDK 1.9 or newer.
 
 - The `pkg` command has these user-visible changes:
   * The package installation command `pkg install foo` now automatically
@@ -303,6 +301,10 @@ major release after 11):
     * `f_fc_Mapper`
     * `fc_fc_Mapper`
 
+Input to the functions `any` and `all` that is non-numeric and non-logical has
+been deprecated in Octave 11 and will throw an error in Octave 12 (or whatever
+version is the first major release after Octave 11).
+
 The following features were deprecated in Octave 9 and have been removed
 from Octave 11.
 
@@ -319,3 +321,57 @@ from Octave 11.
 
   - The `octave_value (const Array<octave_value>& a)` constructor was
     deprecated in Octave 10 and was removed after only one major version.
+
+
+## Summary of bugs fixed for version 11.2.0 (2025-05-28):
+
+> **_Note:_** The SOVERSION of the `liboctinterp` library is incorrect in this
+> version.  Update to Octave 11.3.0 instead.
+
+### Improvements and fixes
+
+- Speed up `pkg install` and provide more output with `-verbose`.
+- `cmach-info.h`: Add visibility attribute to function declarations.
+- Re-implement `weboptions` and affected functions `webread`, `webwrite`
+  ([bug #68079](https://savannah.gnu.org/bugs/?68079)).
+- Remove semicolon after function definitions.
+- Fix possible out-of-bound indexing in N-D Array assignment.
+- Allow classdef constructor to return a classdef array of itself ([bug #59775](https://savannah.gnu.org/bugs/?59775)).
+- Fix pager in CLI on Windows and disable it in the GUI ([bug #68112](https://savannah.gnu.org/bugs/?68112)).
+- Deprecate `all` and `any` for non-numeric/non-logical types ([bug #68172](https://savannah.gnu.org/bugs/?68172)).
+- Silence compiler warning about possible use of uninitialized variable.
+- Fix input validation of `permB` input to `eigs()`.
+- Check floating point subscripts before converting to `octave_idx_type`
+  ([bug #68167](https://savannah.gnu.org/bugs/?68167)).  Reject non-finite, non-integer, and out-of-range
+  floating-point index values before casting them to `octave_idx_type`.
+- Fix `norm (S, 2)` for all-zero sparse matrices ([bug #68254](https://savannah.gnu.org/bugs/?68254)).
+- `colorbar.m`: Change `%!demo #3` to use new syntax with `"location"` first.
+- `max`: Avoid potential integer overflow.
+
+### GUI
+
+- Remove accidental double spaces in language translation files.
+- Use form of "bearbeiten" instead of "editieren" in German translation.
+- Do not hide window of processes started with "system" on Windows.
+- Include missing .svg icon in GUI resources ([bug #68389](https://savannah.gnu.org/bugs/?68389)).
+- Use mouse cursor shape from Qt if possible or SVG ([bug #68389](https://savannah.gnu.org/bugs/?68389)).
+
+### Build system / Tests
+
+- Create Info documentation in build directory, not source directory.
+- Fix Qt help generator for Texinfo 7.3 Function-Index output.
+- Fix `run-octave` to locate documentation in either `srcdir` or `builddir`.
+- `system`: Silence output of self-test.
+- Disable delete warning locally in BISTs as part of cset e17e4e419245.
+
+### Documentation
+
+- Update documentation for `arguments` keyword and add to manual.
+- Format plaintext documentation output to 80 characters.
+- Redo documentation for Appendix F "Grammar and Parser".
+- Use Texinfo commands for better spacing after period used in abbrevation.
+- `genpropdoc.m`: Fix incorrect documentation for `"zdir"` property.
+- Rename some `@node`, `@subsection` entries for clarity and consistency.
+- Set Texinfo `@exampleindent` for better visual appearance.
+- `linsolve.m`: Update documentation ([bug #68283](https://savannah.gnu.org/bugs/?68283)).
+- Update all man pages with new information and modern `groff` syntax.

--- a/pages/community-news.html
+++ b/pages/community-news.html
@@ -14,7 +14,7 @@ the `community-news-page-serial` number by one in order to show new
 entries in the GUI:
 
   this-is-the-gnu-octave-community-news-page
-  community-news-page-serial=33
+  community-news-page-serial=34
 
 -->
 

--- a/pages/community-news.html
+++ b/pages/community-news.html
@@ -14,7 +14,7 @@ the `community-news-page-serial` number by one in order to show new
 entries in the GUI:
 
   this-is-the-gnu-octave-community-news-page
-  community-news-page-serial=32
+  community-news-page-serial=33
 
 -->
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -8,7 +8,7 @@ permalink: download
 
 <div class="primary callout">
   <i class="fas fa-info-circle" style="color:#1779ba;"></i>
-  <strong>GNU Octave 11.2.0</strong> is the latest stable release.
+  <strong>GNU Octave 11.3.0</strong> is the latest stable release.
   (<a href="{{ "/NEWS-11.html" | relative_url }}">Release Notes</a>)
 </div>
 
@@ -36,12 +36,12 @@ which will redirect automatically to a nearby
 [mirror site](https://www.gnu.org/order/ftp.html).
 
 Users are encouraged to verify the integrity of the files they download
-(such as `octave-11.2.0.tar.xz`) as follows:
+(such as `octave-11.3.0.tar.xz`) as follows:
 * Ensure that you are downloading from the Octave website, or from an official
   GNU mirror linked from the Octave website.
 * Download the corresponding signature file. For example, if you like to check
-  the integrity of `octave-11.2.0.tar.xz`, download the signature file
-  `octave-11.2.0.tar.xz.sig`.
+  the integrity of `octave-11.3.0.tar.xz`, download the signature file
+  `octave-11.3.0.tar.xz.sig`.
 * Run the following command to import John W. Eaton's public key (this needs to
   be done only once).
   ```
@@ -49,7 +49,7 @@ Users are encouraged to verify the integrity of the files they download
   ```
 * Verify the integrity of the file you downloaded with a command like
   ```
-  gpg --verify octave-11.2.0.tar.xz.sig
+  gpg --verify octave-11.3.0.tar.xz.sig
   ```
 * If all is well, then the output should say
   ```
@@ -116,15 +116,15 @@ After installation type <code>pkg list</code> to list them.<br>
 </div>
 
 - Windows-64 (recommended)
-  - [octave-11.2.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-installer.exe)
+  - [octave-11.3.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-installer.exe)
     (~ 540 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-installer.exe.sig)
-  - [octave-11.2.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-installer.exe.sig)
+  - [octave-11.3.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64.7z)
     (~ 460 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.7z.sig)
-  - [octave-11.2.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64.7z.sig)
+  - [octave-11.3.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64.zip)
     (~ 820 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64.zip.sig)
 
 <p></p>
 
@@ -137,15 +137,15 @@ After installation type <code>pkg list</code> to list them.<br>
   version above.
   </small>
 
-  - [octave-11.2.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64-installer.exe)
+  - [octave-11.3.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64-installer.exe)
     (~ 540 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64-installer.exe.sig)
-  - [octave-11.2.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64-installer.exe.sig)
+  - [octave-11.3.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64.7z)
     (~ 460 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.7z.sig)
-  - [octave-11.2.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64.7z.sig)
+  - [octave-11.3.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64.zip)
     (~ 820 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.3.0-w64-64.zip.sig)
 
 <p></p>
 

--- a/pages/download.md
+++ b/pages/download.md
@@ -8,7 +8,7 @@ permalink: download
 
 <div class="primary callout">
   <i class="fas fa-info-circle" style="color:#1779ba;"></i>
-  <strong>GNU Octave 11.1.0</strong> is the latest stable release.
+  <strong>GNU Octave 11.2.0</strong> is the latest stable release.
   (<a href="{{ "/NEWS-11.html" | relative_url }}">Release Notes</a>)
 </div>
 
@@ -36,12 +36,12 @@ which will redirect automatically to a nearby
 [mirror site](https://www.gnu.org/order/ftp.html).
 
 Users are encouraged to verify the integrity of the files they download
-(such as `octave-11.1.0.tar.xz`) as follows:
+(such as `octave-11.2.0.tar.xz`) as follows:
 * Ensure that you are downloading from the Octave website, or from an official
   GNU mirror linked from the Octave website.
 * Download the corresponding signature file. For example, if you like to check
-  the integrity of `octave-11.1.0.tar.xz`, download the signature file
-  `octave-11.1.0.tar.xz.sig`.
+  the integrity of `octave-11.2.0.tar.xz`, download the signature file
+  `octave-11.2.0.tar.xz.sig`.
 * Run the following command to import John W. Eaton's public key (this needs to
   be done only once).
   ```
@@ -49,7 +49,7 @@ Users are encouraged to verify the integrity of the files they download
   ```
 * Verify the integrity of the file you downloaded with a command like
   ```
-  gpg --verify octave-11.1.0.tar.xz.sig
+  gpg --verify octave-11.2.0.tar.xz.sig
   ```
 * If all is well, then the output should say
   ```
@@ -116,15 +116,15 @@ After installation type <code>pkg list</code> to list them.<br>
 </div>
 
 - Windows-64 (recommended)
-  - [octave-11.1.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-installer.exe)
+  - [octave-11.2.0-w64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-installer.exe)
     (~ 540 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-installer.exe.sig)
-  - [octave-11.1.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-installer.exe.sig)
+  - [octave-11.2.0-w64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.7z)
     (~ 460 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64.7z.sig)
-  - [octave-11.1.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.7z.sig)
+  - [octave-11.2.0-w64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.zip)
     (~ 820 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64.zip.sig)
 
 <p></p>
 
@@ -137,15 +137,15 @@ After installation type <code>pkg list</code> to list them.<br>
   version above.
   </small>
 
-  - [octave-11.1.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64-installer.exe)
+  - [octave-11.2.0-w64-64-installer.exe](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64-installer.exe)
     (~ 540 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64-installer.exe.sig)
-  - [octave-11.1.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64.7z)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64-installer.exe.sig)
+  - [octave-11.2.0-w64-64.7z](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.7z)
     (~ 460 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64.7z.sig)
-  - [octave-11.1.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64.zip)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.7z.sig)
+  - [octave-11.2.0-w64-64.zip](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.zip)
     (~ 820 MB)
-    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.1.0-w64-64.zip.sig)
+    [[signature]](https://ftpmirror.gnu.org/octave/windows/octave-11.2.0-w64-64.zip.sig)
 
 <p></p>
 


### PR DESCRIPTION
All dates are still pending. But this is something to get started when we are ready to announce the release.
