### PR TITLE
Potentially security-relevant issues should also be reported on Savannah

### DIFF
--- a/pages/support.md
+++ b/pages/support.md
@@ -52,7 +52,8 @@ available to you.
 
 GNU Octave uses the bug tracker at [GNU Savannah]({{ site.bugs_url }}).
 There you can
-[<i class="far fa-plus-square"></i> report a new bug](https://savannah.gnu.org/bugs/?group=octave&func=additem),
+[<i class="far fa-plus-square"></i> report new bugs](https://savannah.gnu.org/bugs/?group=octave&func=additem)
+(including potentially security relevant issues),
 [<i class="far fa-list-alt"></i> browse recent bugs]({{ site.bugs_url }}),
 or [<i class="fas fa-search"></i> search for bugs](https://savannah.gnu.org/bugs/?group=octave&func=search).
 


### PR DESCRIPTION
Clarify that potentially security-relevant issues should be reported on Savannah just like any other bug.
This change is motivated by a recent private email exchange where it was unclear for the reporter how they should proceed.
As agreed during the last online developer meeting, we probably won't need a separate channel for potentially security-relevant issues. Octave can execute arbitrary code by design anyway.